### PR TITLE
Fix for Issue #2

### DIFF
--- a/processMeerKAT/cal_scripts/get_fields.py
+++ b/processMeerKAT/cal_scripts/get_fields.py
@@ -5,6 +5,11 @@ import os
 import processMeerKAT
 import config_parser
 
+
+# Get access to the msmd module for get_fields.py
+import casac
+msmd = casac.casac.msmetadata()
+
 def get_fields(MS):
 
     """Extract field numbers from intent, including calibrators for bandpass, flux, phase & amplitude, and the target.

--- a/processMeerKAT/cal_scripts/partition.py
+++ b/processMeerKAT/cal_scripts/partition.py
@@ -10,9 +10,9 @@ import config_parser
 from config_parser import validate_args as va
 from cal_scripts import get_fields
 
+
 # Get the name of the config file
 args = config_parser.parse_args()
-print(args)
 
 # Parse config file
 taskvals, config = config_parser.parse_config(args['config'])


### PR DESCRIPTION
Check for the existence of the reference antenna in `partition.py`, and if it doesn't exist quit. 

The commit also includes a work-around for the CASA toolkit, which is made available only to the top level script called from CASA. So any script imported from the top level script has to include this workaround, which is to import the `casac` module, and initialise the required tools via that module.