### PR TITLE
Updates to SLURM parameters and field IDs

### DIFF
--- a/processMeerKAT/cal_scripts/get_fields.py
+++ b/processMeerKAT/cal_scripts/get_fields.py
@@ -1,10 +1,14 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
+
 import sys
 import os
 
 import processMeerKAT
 import config_parser
 
+import logging
+logger = logging.getLogger(__name__)
+logging.basicConfig(format="%(asctime)-15s %(levelname)s: %(message)s", level=logging.INFO)
 
 # Get access to the msmd module for get_fields.py
 import casac
@@ -13,7 +17,7 @@ msmd = casac.casac.msmetadata()
 def get_fields(MS):
 
     """Extract field numbers from intent, including calibrators for bandpass, flux, phase & amplitude, and the target.
-    All fields except the calibrator take the first field as the field ID.
+    All fields except the total flux calibrator allow for multiple field IDs.
 
     Arguments:
     ----------
@@ -32,36 +36,75 @@ def get_fields(MS):
         targetfields : int
             Target field."""
 
-    msmd.open(MS)
-
-    fields = ['fluxfield','bpassfield','phasecalfield','targetfields']
-    intents = ['CALIBRATE_FLUX','CALIBRATE_BANDPASS','CALIBRATE_PHASE','TARGET']
     fieldIDs = {}
 
     #Set default for any missing intent as field for intent CALIBRATE_FLUX
-    default_intent = msmd.fieldsforintent('CALIBRATE_FLUX')
-    if default_intent.size == 0:
-        raise KeyError('You must have a field with intent "CALIBRATE_FLUX".')
+    default = msmd.fieldsforintent('CALIBRATE_FLUX')
+    if default.size == 0:
+        raise KeyError('You must have a field with intent "CALIBRATE_FLUX". I only found {0} in dataset "{1}".'.format(msmd.intents(),MS))
 
-    for i,intent in enumerate(intents):
-        fieldID = msmd.fieldsforintent(intent)
-        if fieldID.size > 0:
-            #Extract only one field for bandpass and total flux calibrators
-            if intent in ['CALIBRATE_FLUX','CALIBRATE_BANDPASS']:
-                fieldIDs[fields[i]] = "'{0}'".format(str(fieldID[0]))
-            else:
-                fieldIDs[fields[i]] = "'{0}'".format(','.join([str(fieldID[j]) for j in range(fieldID.size)]))
-        else:
-            print 'Intent "{0}" not found. Setting {1}={2}'.format(intent,fields[i],default_intent)
-            fieldIDs[fields[i]] = "'{0}'".format(default_intent)
+    #Use 'CALIBRATE_PHASE' or if missing, 'CALIBRATE_AMPLI'
+    phasecal_intent = 'CALIBRATE_PHASE'
+    if phasecal_intent not in msmd.intents():
+        phasecal_intent = 'CALIBRATE_AMPLI'
 
-    msmd.close()
+    #Put any extra fields from 'CALIBRATE_FLUX' in phasecal fields
+    fieldIDs['fluxfield'] = get_field(MS,'CALIBRATE_FLUX',multiple=False)
+    extra_fields = list(set(default[1:]) - set(msmd.fieldsforintent(phasecal_intent)))
+    if len(extra_fields) > 0:
+        logger.warn('Putting extra fields with intent "CALIBRATE_FLUX" in "phasecalfield"')
+
+    fieldIDs['bpassfield'] = get_field(MS,'CALIBRATE_BANDPASS',default=default)
+    fieldIDs['phasecalfield'] = get_field(MS,phasecal_intent,default=default)
+    fieldIDs['targetfields'] = get_field(MS,'TARGET',default=default)
+
+    #Put any extra fields with intent CALIBRATE_BANDPASS in phasecal field
+    if len(extra_fields) > 0:
+        fieldIDs['phasecalfield'] = "{0},{1}'".format(fieldIDs['phasecalfield'][:-1],','.join([str(extra_fields[i]) for i in range(len(extra_fields))]))
 
     return fieldIDs
 
+
+def get_field(MS,intent,default=0,multiple=True):
+
+    """Extract a field ID based on intent. If multiple is True, return comma-seperated string, otherwise single field string.
+
+    Arguments:
+    ----------
+    MS : str
+        Input measurement set (relative or absolute path).
+    intent : str
+        Calibration intent.
+    default : int, optional
+        Default field to return if intent missing.
+    multiple : bool, optional
+        Allow multiple fields?
+
+    Returns:
+    --------
+    fields : str
+        Extracted field ID(s)"""
+
+    fields = msmd.fieldsforintent(intent)
+    if fields.size == 0:
+        logger.warn('Intent "{0}" not found in dataset "{1}". Setting to "{2}"'.format(intent,MS,default))
+        fields = "'{0}'".format(default)
+    elif fields.size > 1:
+        if not multiple:
+            logger.warn('Multiple fields found with intent "{0}" in dataset "{1}" - {2}. Only using field "{3}".'.format(intent,MS,fields,fields[0]))
+        else:
+            logger.info('Multiple fields found with intent "{0}" in dataset "{1}" - {2}. Will use all of them.'.format(intent,MS,fields))
+
+    if multiple:
+        fields = "'{0}'".format(','.join([str(fields[i]) for i in range(fields.size)]))
+    else:
+        fields = "'{0}'".format(fields[0])
+
+    return fields
+
 def check_refant(MS,refant,warn=True):
 
-    """Check if reference antenna exists, otherwise throw an error or print a warning.
+    """Check if reference antenna exists, otherwise throw an error or display a warning.
 
     Arguments:
     ----------
@@ -72,27 +115,74 @@ def check_refant(MS,refant,warn=True):
     warn : bool, optional
         Warn the user? If False, raise ValueError."""
 
-    msmd.open(MS)
     ants = msmd.antennanames()
 
     if refant not in ants:
         err = "Reference antenna '{0}' isn't present in input dataset '{1}'. Antennas present are: {2}".format(refant,MS,ants)
         if warn:
-            print '### WARNING: {0}'.format(err)
+            logger.warn(err)
         else:
             raise ValueError(err)
 
-    msmd.close()
+def check_scans(MS,nodes,tasks):
+
+    """Check if the user has set the number of threads to a number larger than the number of scans.
+    If so, display a warning and return the number of thread to be replaced in their config file.
+
+    Arguments:
+    ----------
+    MS : str
+        Input measurement set (relative or absolute path).
+    nodes : int
+        The number of nodes set by the user.
+    tasks : int
+        The number of tasks (per node) set by the user.
+
+    Returns:
+    --------
+    threads : dict
+        A dictionary with updated values for nodes and tasks per node to match the number of scans."""
+
+    nscans = msmd.nscans()
+    limit = int(1.1*(nscans + 1))
+
+    if abs(nodes * tasks - limit) > 0.1*limit:
+        logger.warn('The number of threads ({0} node(s) x {1} task(s) = {2}) is not ideal compared to the number of scans ({3}) for "{4}".'.format(nodes,tasks,nodes*tasks,nscans,MS))
+
+        #Start with one node, and increase count of nodes (and then tasks per node) until limit reached
+        nodes = 1
+        while nodes * tasks < limit:
+            if nodes < processMeerKAT.TOTAL_NODES_LIMIT:
+                nodes += 1
+            elif tasks < processMeerKAT.NTASKS_PER_NODE_LIMIT:
+                tasks += 1
+            else:
+                break
+
+        logger.warn('Config file has been updated to use {0} node(s) and {1} task(s) per node.'.format(nodes,tasks))
+        if nodes*tasks != limit:
+            logger.info('For the best results, update your config file so that nodes x tasks per node = {0}.'.format(limit))
+
+    threads = {'nodes' : nodes, 'ntasks_per_node' : tasks}
+    return threads
+
 
 def main():
 
     args = processMeerKAT.parse_args()
+    msmd.open(args.MS)
+
     refant = config_parser.parse_config(args.config)[0]['crosscal']['refant']
     check_refant(args.MS, refant, warn=True)
 
     fields = get_fields(args.MS)
     config_parser.overwrite_config(args.config, conf_dict=fields, conf_sec='fields')
+    logger.info('Field IDs written to "{0}". Edit this file to change any field IDs (comma-seperated string for multiple IDs).'.format(args.config))
 
+    threads = check_scans(args.MS,args.nodes,args.ntasks_per_node)
+    config_parser.overwrite_config(args.config, conf_dict=threads, conf_sec='slurm')
+
+    msmd.close()
 
 if __name__ == "__main__":
     main()

--- a/processMeerKAT/cal_scripts/validate_input.py
+++ b/processMeerKAT/cal_scripts/validate_input.py
@@ -109,7 +109,9 @@ def validateinput():
         config_parser.overwrite_config(args['config'], conf_sec='crosscal', conf_dict={'badants':badants})
     else:
         refant = va(taskvals, 'crosscal', 'refant', str)
+        msmd.open(visname)
         get_fields.check_refant(MS=visname, refant=refant, warn=False)
+        msmd.close()
 
     if not os.path.exists(visname):
         raise IOError("Path to MS %s not found" % (visname))

--- a/processMeerKAT/config_parser.py
+++ b/processMeerKAT/config_parser.py
@@ -1,8 +1,9 @@
-#! /usr/bin/env python
+#!/usr/bin/env python2.7
 
 import argparse
 import ConfigParser
 import ast
+import processMeerKAT
 
 def parse_args():
     """
@@ -45,11 +46,13 @@ def parse_config(filename):
     return taskvals, config
 
 
-def overwrite_config(filename, conf_sec='', conf_dict={}):
+def overwrite_config(filename, conf_dict={}, conf_sec=''):
 
     config_dict,config = parse_config(filename)
 
     if conf_sec not in config.sections():
+        processMeerKAT.logger.debug('Writing [{0}] section in config file "{1}" with:\n{2}.'.format(conf_sec,filename,conf_dict))
+
         config.add_section(conf_sec)
 
         for key in conf_dict.keys():
@@ -60,6 +63,8 @@ def overwrite_config(filename, conf_sec='', conf_dict={}):
         config_file.close()
 
     else:
+        processMeerKAT.logger.debug('Overwritting [{0}] section in config file "{1}" with:\n{2}.'.format(conf_sec,filename,conf_dict))
+
         for key in conf_dict.keys():
             config.set(conf_sec, key, str(conf_dict[key]))
 


### PR DESCRIPTION
Updated memory limit (per node) to 244 GB (250000 MB), with all memory arguments now in GB, and the default memory (per node) as this limit. Updated default number of nodes to 10 (i.e. 10 nodes x 8 tasks per node = 80 threads) to suit a typical number of scans. By default, if there are too few or too many threads compared to scans, a warning will be displayed and the number of nodes and tasks per node will be overwritten in the config file, to the lowest number of nodes (i.e. multiple of tasks per node) that is above a limit defined by the number of scans + 1 + 10%. Or if the maximum node count is reached, the number of tasks per node will increase by one until either of both limits is reached (scans + 1 + 10% or maximum number of tasks per node).

Added option [-l --local] to allow for the initial CASA call to extract fields to be made without srun (e.g. on login node, or another fat node). If srun is used, a small job is deliberately requested for efficiency, which uses 1 task on 1 node, with 4 GB memory and a 5 minute time limit.

config_parser.py and and get_fields.py now use logging, rather than print statements. get_fields.py now only opens the MS once (with msmd), rather than several times, which was costly due to the internal consistency checks that were performed upon opening.

Updated how the field IDs are extracted. Only the first field ID for the total flux calibrator is extracted, and all others are appended to the phase calibrator list (if not already present). Warnings are displayed when there are multiple IDs. If intent 'CALIBRATE_PHASE' isn't present, 'CALIBRATE_AMPLI' is used.