### PR TITLE
Fixed the MSTRANSFORM/chanaverage issue by checking the value of chan…

### DIFF
--- a/processMeerKAT/cal_scripts/split.py
+++ b/processMeerKAT/cal_scripts/split.py
@@ -17,10 +17,16 @@ def split_vis(visname, spw, fields, specavg, timeavg, keepmms):
 
             outname = '%s.%s.%s' % (outputbase, fname, extn)
             if not os.path.exists(outname):
+                # If specavg=1 then don't do averaging (set chanaverage=False)
+                if specavg<2:
+                    chanaverage=False
+                else:
+                    chanaverage=True
+                    
                 mstransform(vis=visname, outputvis=outname, datacolumn='corrected',
-                        field=fname, spw=spw, keepflags=False, createmms=keepmms,
-                        chanaverage=True, chanbin=specavg, timeaverage=True,
-                        timebin=timeavg, usewtspectrum=True)
+                            field=fname, spw=spw, keepflags=False, createmms=keepmms,
+                            chanaverage=chanaverage, chanbin=specavg, timeaverage=True,
+                            timebin=timeavg, usewtspectrum=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Updated split.py, sets chanaverage=False if chanbin<2 (I prefer this to `if chanbin==1...`). 

Testing on xmm-lss data are successful. 

Fixes issue #34.

