### PR TITLE
Branch to image using multiple tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 *.egg-info
 *.swp # vim swap files
 
+.ipynb_checkpoints
+
 build/
 dist/

--- a/processMeerKAT/bookkeeping.py
+++ b/processMeerKAT/bookkeeping.py
@@ -187,6 +187,12 @@ def get_selfcal_args(vis,loop,nloops,nterms,deconvolver,discard_nloops,calmode,o
     msmd = msmetadata()
     qa = quanta()
 
+    if ',' in vis:                 #detect if we are combining tracks
+        vis = vis.split(',')[0]
+        combTracks = True
+    else:
+        combTracks = False
+    
     if os.path.exists('{0}/SUBMSS'.format(vis)):
         tmpvis = glob.glob('{0}/SUBMSS/*'.format(vis))[0]
     else:
@@ -212,6 +218,9 @@ def get_selfcal_args(vis,loop,nloops,nterms,deconvolver,discard_nloops,calmode,o
         targetfield = msmd.fieldsforname(targetfield)[0]
 
     target_str = msmd.namesforfields(targetfield)[0]
+
+    if combTracks:                           #currently setting visbase to the CWD in the case of combining tracks
+        visbase = os.getcwd().split('/')[-1]
 
     if '.ms' in visbase and target_str not in visbase:
         basename = visbase.replace('.ms','.{0}'.format(target_str))

--- a/processMeerKAT/default_config_comb.txt
+++ b/processMeerKAT/default_config_comb.txt
@@ -1,0 +1,97 @@
+[data]
+vis = ''
+
+[fields]
+bpassfield = ''
+fluxfield = ''
+phasecalfield = ''
+targetfields = ''
+extrafields = ''
+
+[slurm]                           # See processMeerKAT.py -h for documentation
+nodes = 1
+ntasks_per_node = 8
+plane = 1
+mem = 232                         # Use this many GB of memory (per node)
+partition = 'Main'                # SLURM partition to use
+exclude = ''                      # SLURM nodes to exclude
+time = '12:00:00'
+submit = False
+container = '/idia/software/containers/casa-6.6.0-modular.sif'
+mpi_wrapper = 'mpirun'
+name = ''
+dependencies = ''
+account = 'b03-idia-ag'
+reservation = ''
+modules = ['openmpi/4.0.3']
+verbose = False
+precal_scripts = []
+postcal_scripts = [('prepareTracks.py', True, ''), ('science_image.py', False, '')]
+scripts = []
+
+[crosscal]
+minbaselines = 4                  # Minimum number of baselines to use while calibrating
+chanbin = 1                       # Number of channels to average before calibration (during partition)
+width = 1                         # Number of channels to (further) average after calibration (during split)
+timeavg = '8s'                    # Time interval to average after calibration (during split)
+createmms = True                  # Create MMS (True) or MS (False) for cross-calibration during partition
+keepmms = True                    # Output MMS (True) or MS (False) during split
+spw = '*:880~933MHz,*:960~1010MHz,*:1010~1060MHz,*:1060~1110MHz,*:1110~1163MHz,*:1299~1350MHz,*:1350~1400MHz,*:1400~1450MHz,*:1450~1500MHz,*:1500~1524MHz,*:1630~1680MHz' # Spectral window / frequencies to extract for MMS
+nspw = 11                         # Number of spectral windows to split into
+calcrefant = False                # Calculate reference antenna in program (overwrites 'refant')
+refant = 'm059'                   # Reference antenna name / number
+standard = 'Stevens-Reynolds 2016'# Flux density standard for setjy
+badants = []                      # List of bad antenna numbers (to flag)
+badfreqranges = [ '933~960MHz',   # List of bad frequency ranges (to flag)
+                  '1163~1299MHz',
+                  '1524~1630MHz']
+
+[selfcal]
+nloops = 2                        # Number of clean + bdsf loops.
+loop = 0                          # If nonzero, adds this number to nloops to name images or continue previous run
+cell = '1.5arcsec'
+robust = -0.5
+imsize = [6144, 6144]
+wprojplanes = 512
+niter = [10000, 50000, 50000]
+threshold = ['0.5mJy', 10, 10]    # After loop 0, S/N values if >= 1.0, otherwise Jy
+nterms = 2                        # Number of taylor terms
+gridder = 'wproject'
+deconvolver = 'mtmfs'
+calmode = ['','p']                # '' to skip solving (will also exclude mask for this loop), 'p' for phase-only and 'ap' for amplitude and phase
+solint = ['','1min']
+uvrange = ''                      # uv range cutoff for gaincal
+flag = True                       # Flag residual column after selfcal?
+gaintype = 'G'                    # Use 'T' for polarisation on linear feeds (e.g. MeerKAT)
+discard_nloops = 0                # Discard this many selfcal solutions (e.g. from quick and dirty image) during subsequent loops (only considers when calmode !='')
+outlier_threshold = 0.0           # S/N values if >= 1.0, otherwise Jy
+outlier_radius = 0.0              # Radius in degrees for identifying outliers in RACS
+method ='default'                 # Mask creation method for science imaging (i.e. image or cube mask. default = image)
+
+[image]
+cell = '2arcsec'
+robust = 0.0
+imsize = [1500, 1500]
+wprojplanes = 128
+niter = 50000
+threshold = '0.1mJy'              # S/N value if >= 1.0 and rmsmap != '', otherwise Jy
+multiscale = [0, 5, 10, 15]
+nterms = 2                        # Number of taylor terms
+gridder = 'wproject'
+deconvolver = 'multiscale'
+specmode = 'cube'                 # 'mfs' for continuum image, 'cube' for spectral-line image
+uvtaper = ''
+restfreq = '1420.406MHz'          # HI line (change for other emission lines - e.g. OH)
+fitspw = ''                       # Emission line frequencies to exclude from fit to continuum during uvcontsub, and SPW to select for imaging when specmode='cube'
+fitorder = 1                      # Order of polynomial fit to continuum during uvcontsub
+restoringbeam = ''
+stokes = 'I'
+pbthreshold = 0.1                 # Threshold below which to mask the PB for PB correction
+pbband = 'LBand'                  # Which band to use to generate the PB - one of "LBand" "SBand" or "UHF"
+mask = ''
+rmsmap = ''
+outlierfile = ''
+
+[run]                             # Internal variables for pipeline execution
+continue = True
+dopol = False

--- a/processMeerKAT/prepareTracks.py
+++ b/processMeerKAT/prepareTracks.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import glob
+from shutil import copytree
+
+import config_parser
+from config_parser import validate_args as va
+import bookkeeping
+
+from casatasks import *
+logfile=casalog.logfile()
+casalog.setlogfile('logs/{SLURM_JOB_NAME}-{SLURM_JOB_ID}.casa'.format(**os.environ))
+import casampi
+
+from casatools import msmetadata,image
+msmd = msmetadata()
+ia = image()
+
+import logging
+from time import gmtime
+logging.Formatter.converter = gmtime
+logger = logging.getLogger(__name__)
+logging.basicConfig(format="%(asctime)-15s %(levelname)s: %(message)s", level=logging.INFO)
+
+
+from aux_scripts.concat import check_output, get_infiles
+from selfcal_scripts.selfcal_part2 import find_outliers, mask_image
+
+
+def deconvolveMSs(vis, refant, dopol, nloops, loop, cell, robust, imsize, wprojplanes, niter, threshold, uvrange, nterms,
+                  gridder, deconvolver, solint, calmode, discard_nloops, gaintype, outlier_threshold, outlier_radius, flag):
+    
+    imbase,imagename,outimage,pixmask,rmsfile,caltable,prev_caltables,threshold,outlierfile,cfcache,_,_,_,_ = bookkeeping.get_selfcal_args(vis,loop,nloops,nterms,deconvolver,discard_nloops,calmode,outlier_threshold,outlier_radius,threshold,step='tclean')
+    calcpsf = True
+
+    vis = vis.split(',')
+    
+    tclean(vis=vis, selectdata=False, datacolumn='corrected', imagename=imagename,
+            imsize=imsize[loop], cell=cell[loop], stokes='I', gridder=gridder[loop],
+            wprojplanes = wprojplanes[loop], deconvolver = deconvolver[loop], restoration=True,
+            weighting='briggs', robust = robust[loop], niter=niter[loop], outlierfile=outlierfile,
+            threshold=threshold[loop], nterms=nterms[loop], calcpsf=calcpsf, # cfcache = cfcache,
+            pblimit=-1, mask=pixmask, parallel = True)
+ 
+def makeMask(params, method='default'):
+    
+    if method == 'default':
+        rmsmap, outlierfile = find_outliers(**params,step='bdsf')
+        pixmask = mask_image(**params)
+             
+    #elif method == "your method":
+        #space to add different, user-defined methods into the pipeline. e.g., a spectral mask. 
+
+    return rmsmap, outlierfile, pixmask
+    
+        
+if __name__ == '__main__':
+
+    args,params = bookkeeping.get_selfcal_params()
+    method = params.pop('method')[0]
+    
+    ##blind deconvolution
+    deconvolveMSs(**params)
+    
+    #make mask for imaging    
+    rmsmap, outlierfile, pixmask = makeMask(params, method=method)
+    
+    loop = params['loop']
+    
+    #update config file for science imaging
+    if config_parser.has_section(args['config'], 'image'):
+        if config_parser.get_key(args['config'], 'image', 'specmode') != 'cube':
+            # Don't copy over continuum mask for cube-mode science imaging; allow for 3D mask (e.g. SoFiA)
+            config_parser.overwrite_config(args['config'], conf_dict={'mask' : "'{0}'".format(pixmask)}, conf_sec='image')
+        config_parser.overwrite_config(args['config'], conf_dict={'rmsmap' : "'{0}'".format(rmsmap)}, conf_sec='image')
+        config_parser.overwrite_config(args['config'], conf_dict={'outlierfile' : "'{0}'".format(outlierfile)}, conf_sec='image')
+
+    bookkeeping.rename_logs(logfile)

--- a/processMeerKAT/science_image.py
+++ b/processMeerKAT/science_image.py
@@ -103,7 +103,11 @@ def do_pb_corr(inpimage, pbthreshold=0, pbband='LBand'):
 
 def science_image(vis, spw, cell, robust, imsize, wprojplanes, niter, threshold, multiscale, nterms, gridder, deconvolver, specmode, uvtaper, restfreq, restoringbeam, stokes, mask, rmsmap, outlierfile, keepmms, pbthreshold, pbband, fitspw):
 
-    visbase = os.path.split(vis.rstrip('/ '))[1] # Get only vis name, not entire path
+    if ',' in vis:           #currently setting visbase to the CWD in the case of combining tracks
+        vis = vis.split(',')
+        visbase = os.getcwd().split('/')[-1]
+    else:
+        visbase = os.path.split(vis.rstrip('/ '))[1] # Get only vis name, not entire path
     extn = '.ms' if keepmms==False else '.mms'
     imagename = visbase.replace(extn, '.science_image') # Images will be produced in $CWD
 
@@ -125,7 +129,9 @@ def science_image(vis, spw, cell, robust, imsize, wprojplanes, niter, threshold,
         parallel = False
         if fitspw != '':
             spw = fitspw
-
+            if isinstance(vis,list): #in the case of combining tracks, need a list equal to the number of MSs. Why? I don't know, but it didn't work with a single value
+                spw = [spw]*len(vis)
+                
     if not os.path.exists(imname):
 
         tclean(vis=vis, selectdata=False, datacolumn='corrected', imagename=imagename,

--- a/processMeerKAT/selfcal_scripts/selfcal_part2.py
+++ b/processMeerKAT/selfcal_scripts/selfcal_part2.py
@@ -109,7 +109,7 @@ def find_outliers(vis, refant, dopol, nloops, loop, cell, robust, imsize, wprojp
     outlier_min_flux = 1e-3 # 1 mJy
 
     if step != 'sky':
-        pybdsf(imbase,rmsfile,imagename,outimage,thresh,maskfile,cat)
+        pybdsf(imbase,rmsfile,imagename,outimage,thresh,maskfile,cat,loop)
 
     #Store before potentially updating to mJy
     orig_threshold = outlier_threshold
@@ -283,7 +283,7 @@ def find_outliers(vis, refant, dopol, nloops, loop, cell, robust, imsize, wprojp
 
                     if os.path.exists(im):
                         #Run PyBDSF on outlier and update mask
-                        pybdsf(imbase,rmsfile,base,im,outlier_snr,outlier_mask,outlier_cat,write_all=False)
+                        pybdsf(imbase,rmsfile,base,im,outlier_snr,outlier_mask,outlier_cat,loop,write_all=False)
                         outlier_pixmask = mask_image(**local,outlier_base=base,outlier_image=im)
                     else:
                         #Use main image, run PyBDSF on box around outlier, and update mask
@@ -300,7 +300,7 @@ def find_outliers(vis, refant, dopol, nloops, loop, cell, robust, imsize, wprojp
                         else:
                             logger.warning("Image '{0}' doesn't exist. Assuming source exists inside main image, so running PyBDSF on '{1}' using {2}x{2} pixel trim box.".format(im,outimage,outlier_imsize))
 
-                        pybdsf(imbase,rmsfile,imagename,outimage,outlier_snr,outlier_mask,outlier_cat,trim_box=trim_box,write_all=False)
+                        pybdsf(imbase,rmsfile,imagename,outimage,outlier_snr,outlier_mask,outlier_cat,loop,trim_box=trim_box,write_all=False)
                         outlier_pixmask = mask_image(**local,outlier_base=base)
 
                     mask = 'mask={0}'.format(outlier_pixmask)

--- a/processMeerKAT/selfcal_scripts/selfcal_part2.py
+++ b/processMeerKAT/selfcal_scripts/selfcal_part2.py
@@ -64,7 +64,7 @@ def selfcal_part2(vis, refant, dopol, nloops, loop, cell, robust, imsize, wprojp
     else:
         logger.warning("Skipping selfcal loop {0} since calmode == ''.".format(loop))
 
-def pybdsf(imbase,rmsfile,imagename,outimage,thresh,maskfile,cat,trim_box=None,write_all=True):
+def pybdsf(imbase,rmsfile,imagename,outimage,thresh,maskfile,cat,loop,trim_box=None,write_all=True):
 
     fitsname = outimage
 


### PR DESCRIPTION
Hi processMeerKAT devs, 

I thought you might be interested, I have made a script that enables the pipeline to be used to image multiple tracks into one data product.

It works in a similar way to the default pipeline; you build a parameter file with the -BC (--combtracks) flag while supplying a comma-separated list of (M)MS to the -MS flag. These MSs should be calibrated in the case of continuum, or continuum-subtracted in the case of spectral lines.

The pipeline then imports from the existing selfcal scripts to do a blind deconvolution of the sky and make a mask and rms map, and the results are then fed into the existing science_image script. 

I tried to keep changes to existing scripts minimal, most changes are to allow the list of MSs to be passed through verification functions successfully. 
I have verified it reduces and images data fine, but let me know if there are any unit tests you would like it to run through. 

The commits also fix a possible bug in selfcal_part2.py, where the 'loop' variable is referenced but not fed into the function at any point. 
